### PR TITLE
Remove nethserver-hotsync-conf from post-restore

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -39,5 +39,5 @@ event_templates($event, qw(
                 /etc/stunnel/stunnel.pem
 ));
 templates2events("/etc/stunnel/stunnel.pem","certificate-update");
-event_actions('post-restore-config', 'nethserver-hotsync-conf' => '40');
+event_actions('post-restore-config', 'nethserver-hotsync-yum-plugins-conf' => '40');
 event_actions('post-restore-config', 'nethserver-hotsync-load-mysql-tables' => '80');

--- a/root/etc/e-smith/events/actions/nethserver-hotsync-conf
+++ b/root/etc/e-smith/events/actions/nethserver-hotsync-conf
@@ -50,8 +50,6 @@ if ($role eq 'slave') {
   }
 } elsif ($role eq 'master' || $role eq 'server') {
   #configuring master
-  #enable yum nethserver plugin
-  system("sed","-i", 's/enabled = 0/enabled = 1/g',"/etc/yum/pluginconf.d/nethserver_events.conf");
   if ($role eq 'master' && $hotsync_status eq "enabled" && $slave_host ne "") {
     system("config", "setprop", "stunnel", "status", "enabled");
     system("/sbin/e-smith/signal-event", "runlevel-adjust");

--- a/root/etc/e-smith/events/actions/nethserver-hotsync-load-mysql-tables
+++ b/root/etc/e-smith/events/actions/nethserver-hotsync-load-mysql-tables
@@ -29,7 +29,7 @@ if [ ! -f $backup_dir/mysql.dump ]; then
     exit 0
 fi
 
-if [[ x$(/sbin/e-smith/config getprop hotsync mysql) == "xdisabled" ]] ; then 
+if [[ x$(/sbin/e-smith/config getprop hotsync databases) == "xdisabled" ]] ; then 
     exit 0
 fi
 

--- a/root/etc/e-smith/events/actions/nethserver-hotsync-yum-plugins-conf
+++ b/root/etc/e-smith/events/actions/nethserver-hotsync-yum-plugins-conf
@@ -1,0 +1,35 @@
+#!/usr/bin/perl 
+
+#
+# Copyright (C) 2017 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use strict;
+use esmith::ConfigDB;
+
+my $conf = esmith::ConfigDB->open || die("Could not open config db\n");
+my $hotsync = $conf->get('hotsync') || die("there's no hotsync key\n");
+my $role = $hotsync->prop('role')  || "";
+
+} if ($role eq 'master' || $role eq 'server') {
+  #enable yum nethserver plugin
+  system("sed","-i", 's/enabled = 0/enabled = 1/g',"/etc/yum/pluginconf.d/nethserver_events.conf");
+}
+
+


### PR DESCRIPTION
now yum plugin is enabled after post-restore by nethserver-hotsync-yum-plugins-conf action