### PR TITLE
Load configuration backup on interface

### DIFF
--- a/root/etc/hotsync.d/mysql.sh
+++ b/root/etc/hotsync.d/mysql.sh
@@ -31,8 +31,6 @@ if rpm -q --quiet nethserver-mysql; then
     if [[ $DATABASES != 'disabled' ]]; then
         # dump mysql tables
         /etc/e-smith/events/actions/mysql-dump-tables
-        #include mysql password file
-        echo "/etc/my.pwd" >> ${INCLUDE_FILE}
         #include mysql backup
         echo "/var/lib/nethserver/backup/mysql/" >> ${INCLUDE_FILE}
     fi

--- a/root/usr/sbin/hotsync
+++ b/root/usr/sbin/hotsync
@@ -108,6 +108,8 @@ echo "/var/lib/nethserver/db/" >> ${EXCLUDE_FILE}
 
 #copy backup config file
 echo "/var/lib/nethserver/backup/backup-config.tar.xz" >> ${INCLUDE_FILE}
+echo "/var/lib/nethserver/backup/backup-config.tar.xz-content.md5" >> ${INCLUDE_FILE}
+echo "/var/lib/nethserver/backup/backup-config.tar.xz.md5" >> ${INCLUDE_FILE}
 
 #copy passwd and group file 
 echo "/etc/passwd" >> ${INCLUDE_FILE}

--- a/root/usr/sbin/hotsync-slave-packages
+++ b/root/usr/sbin/hotsync-slave-packages
@@ -25,3 +25,11 @@
 
 # launch reinstall action
 /etc/e-smith/events/actions/restore-config-reinstall
+
+# load configuration backup on interface if its md5 is equal to its md5file
+backupfile="/var/lib/nethserver/backup/backup-config.tar.xz"
+md5file="${backupfile}.md5"
+md5sum backupfile 2>/dev/null | grep -q $(cut -f 1 -d ' ' "${md5file}")
+if [[ $? == 0 ]]; then
+    /etc/e-smith/events/actions/nethserver-backup-config-push2history
+fi


### PR DESCRIPTION
- check that configuration backup md5 is equal to its md5file, to avoid inconsistency if this action is executed during backup file copy
- launch nethserver-backup-config-push2history action to load configuration backup on interface