### PR TITLE
Do not force rsync to use numeric uids

### DIFF
--- a/root/usr/sbin/hotsync
+++ b/root/usr/sbin/hotsync
@@ -111,10 +111,6 @@ echo "/var/lib/nethserver/backup/backup-config.tar.xz" >> ${INCLUDE_FILE}
 echo "/var/lib/nethserver/backup/backup-config.tar.xz-content.md5" >> ${INCLUDE_FILE}
 echo "/var/lib/nethserver/backup/backup-config.tar.xz.md5" >> ${INCLUDE_FILE}
 
-#copy passwd and group file 
-echo "/etc/passwd" >> ${INCLUDE_FILE}
-echo "/etc/group" >> ${INCLUDE_FILE}
-
 #copy yum configuration
 cat >> ${INCLUDE_FILE} << EOF
 /etc/yum/vars
@@ -145,7 +141,7 @@ IFS=$SAVEIFS
 #copy files with rsync
 # -q
 #    --files-from=${INCLUDE_FILE} --exclude=.ssh/authorized_keys \
-RSYNC_PASSWORD=`/sbin/e-smith/config getprop rsyncd password` /usr/bin/rsync ${XTRA_OPTS} -z -r -a -H -A --delete --numeric-ids \
+RSYNC_PASSWORD=`/sbin/e-smith/config getprop rsyncd password` /usr/bin/rsync ${XTRA_OPTS} -z -r -a -H -A --delete \
     --files-from=${INCLUDE_FILE} \
     --exclude-from=${EXCLUDE_FILE} \
     / "rsync://hotsyncuser@127.0.0.1/hotsync/" 2>/tmp/hotsync.log


### PR DESCRIPTION
- If possible, use user/group names otherwise fall back to numeric uids
- Do not sync `/etc/passwd` `/etc/group`: uids/gids from anaconda in newer NethServer versions could differ from older ones

https://github.com/NethServer/dev/issues/5430