### PR TITLE
script. fix machines.target status

### DIFF
--- a/root/etc/hotsync.d/nsdc.sh
+++ b/root/etc/hotsync.d/nsdc.sh
@@ -33,8 +33,12 @@ if rpm -q --quiet nethserver-dc; then
     if [[ -d "/var/lib/machines/nsdc" ]]; then
         echo "/var/lib/machines/nsdc" >> ${INCLUDE_FILE}
     fi
-    # check if nsdc is enabled
+    # sync nsdc status
     if [[ -d "/etc/systemd/system/machines.target.wants" ]]; then
         echo "/etc/systemd/system/machines.target.wants" >> ${INCLUDE_FILE}
+    fi
+    # sync machines.target status
+    if [[ -d "/etc/systemd/system/multi-user.target.wants" ]]; then
+        echo "/etc/systemd/system/multi-user.target.wants" >> ${INCLUDE_FILE}
     fi
 fi


### PR DESCRIPTION
Fixed machines.target status to start nsdc on boot.
Refer to https://github.com/NethServer/dev/issues/6011